### PR TITLE
Polish site visuals: hero, components and global styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,4 +4,13 @@
 
 html { scroll-behavior: smooth; }
 
-body { @apply bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100; }
+body {
+  @apply bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100 antialiased;
+  background-image: radial-gradient(circle at top, rgba(22, 163, 74, 0.12), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.08), transparent 40%);
+}
+
+.dark body {
+  background-image: radial-gradient(circle at top, rgba(22, 163, 74, 0.18), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.1), transparent 40%);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,8 @@
-import Link from 'next/link';
 import Button from '@/components/button';
 import Section from '@/components/section';
 import Card from '@/components/card';
 import Timeline from '@/components/timeline';
-import KPI from '@/components/kpi';
-import Testimonials from '@/components/testimonial';
-import { Check, Target, ServerCog, Brain, Factory, LineChart, GraduationCap, ShieldCheck, Cog } from 'lucide-react';
+import { Target, ServerCog, Factory, LineChart, ShieldCheck, Cog } from 'lucide-react';
 
 const methodology = ['Diagnóstico y Rentabilidad', 'Hoja de Ruta 3 Años', 'MVPs & Pilotos Rápidos', 'Escalado y Estandarización', 'Gobierno del Dato'];
 
@@ -13,19 +10,51 @@ export default function Home() {
   return (
     <main>
       {/* HERO SECTION */}
-      <Section>
-        <div className="text-center space-y-6 py-12">
+      <Section className="relative overflow-hidden">
+        <div aria-hidden className="absolute inset-0 -z-10">
+          <div className="absolute -top-32 right-0 h-80 w-80 rounded-full bg-brand/15 blur-3xl" />
+          <div className="absolute bottom-0 left-6 h-72 w-72 rounded-full bg-emerald-400/15 blur-3xl" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.9),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.6),_transparent_60%)]" />
+        </div>
+        <div className="text-center space-y-6 py-10">
+          <p className="mx-auto inline-flex items-center gap-2 rounded-full border border-brand/20 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-brand shadow-sm dark:border-brand/40 dark:bg-slate-900/70">
+            Consultoría Estratégica + IA aplicada
+          </p>
           <h1 className="text-4xl md:text-6xl font-heading font-bold tracking-tight">
             Maximiza la rentabilidad operativa con <span className="text-brand">IA y rigor aeroespacial</span>.
           </h1>
-          <p className="text-xl text-slate-600 dark:text-slate-300 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-lg md:text-xl text-slate-600 dark:text-slate-300 max-w-3xl mx-auto leading-relaxed">
             Transformo constructoras e industrias en organizaciones de alto rendimiento. Integro procesos estandarizados, ERP (Business Central) e IA predictiva para blindar el margen y eliminar ineficiencias.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
             <Button as="a" href="/contacto" variant="primary" className="text-lg px-8">Agenda una reunión estratégica</Button>
             <Button as="a" href="/jose-moya.pdf" variant="secondary">Descargar perfil ejecutivo</Button>
           </div>
-          <p className="text-sm text-slate-500 pt-8">
+          <div className="grid gap-4 pt-8 md:grid-cols-3 text-left">
+            {[
+              {
+                title: 'Margen defendido',
+                copy: 'Procesos y KPIs que aseguran rentabilidad estable desde la obra hasta finanzas.'
+              },
+              {
+                title: 'ERP + datos unificados',
+                copy: 'Business Central como columna vertebral para decisiones en tiempo real.'
+              },
+              {
+                title: 'IA lista para operar',
+                copy: 'Automatizaciones predictivas sin fricción en operaciones críticas.'
+              }
+            ].map((item) => (
+              <div
+                key={item.title}
+                className="rounded-2xl border border-slate-200/80 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/60"
+              >
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{item.title}</p>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{item.copy}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-sm text-slate-500 pt-6">
             Estrategia aplicada en: <span className="font-semibold text-slate-700 dark:text-slate-200">Grupo Aconser • Aciturri • San Telmo Business School</span>
           </p>
         </div>
@@ -33,24 +62,33 @@ export default function Home() {
 
       {/* SECTORES - ENFOQUE INGENIERÍA */}
       <Section id="sectores">
-        <h2 className="text-3xl font-heading mb-12 text-center font-bold">Especialización Sectorial</h2>
+        <div className="text-center mb-12">
+          <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Especialización</p>
+          <h2 className="text-3xl font-heading mt-3 font-bold">Especialización Sectorial</h2>
+        </div>
         <div className="grid md:grid-cols-3 gap-8">
-          <Card className="border-t-4 border-t-brand hover:shadow-lg transition-shadow">
-            <Factory className="h-10 w-10 text-brand mb-4" />
+          <Card className="group">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand mb-4 transition-colors group-hover:bg-brand group-hover:text-white">
+              <Factory className="h-6 w-6" />
+            </div>
             <h3 className="text-xl font-bold mb-3">Construcción 4.0</h3>
             <p className="text-slate-600 dark:text-slate-300">
               Industrialización de procesos y control de obra en tiempo real. Reducción de variabilidad y carga física mediante estandarización Lean.
             </p>
           </Card>
-          <Card className="border-t-4 border-t-brand hover:shadow-lg transition-shadow">
-            <ServerCog className="h-10 w-10 text-brand mb-4" />
+          <Card className="group">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand mb-4 transition-colors group-hover:bg-brand group-hover:text-white">
+              <ServerCog className="h-6 w-6" />
+            </div>
             <h3 className="text-xl font-bold mb-3">Energía y Renovables</h3>
             <p className="text-slate-600 dark:text-slate-300">
               Gobierno de costes en proyectos complejos. Integración de compras inteligentes para evitar desviaciones en P&L.
             </p>
           </Card>
-          <Card className="border-t-4 border-t-brand hover:shadow-lg transition-shadow">
-            <Target className="h-10 w-10 text-brand mb-4" />
+          <Card className="group">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand mb-4 transition-colors group-hover:bg-brand group-hover:text-white">
+              <Target className="h-6 w-6" />
+            </div>
             <h3 className="text-xl font-bold mb-3">Aeronáutica e Industrial</h3>
             <p className="text-slate-600 dark:text-slate-300">
               Gestión de *ramp-ups* y calidad total. Aplicación de OEE, FPY y Takt Time para maximizar la capacidad productiva.
@@ -60,56 +98,61 @@ export default function Home() {
       </Section>
 
       {/* VALOR DIFERENCIAL - EL MÉTODO AEROESPACIAL */}
-      <Section className="bg-slate-50 dark:bg-slate-800/50 rounded-3xl my-12">
-        <div className="grid md:grid-cols-2 gap-12 items-center p-6">
-          <div>
-            <h2 className="text-3xl font-heading font-bold mb-6">Por qué un Ingeniero Aeroespacial en tu empresa</h2>
-            <p className="text-lg mb-6 text-slate-600 dark:text-slate-300">
-              La construcción y la industria moderna ya no admiten la gestión por intuición. Aplico la mentalidad de "cero defectos" y sistemas complejos al negocio.
-            </p>
-            <ul className="space-y-4">
-              <li className="flex items-start gap-3">
-                <ShieldCheck className="h-6 w-6 text-brand mt-1" />
-                <div>
-                  <strong className="block text-slate-900 dark:text-slate-100">Rigor y Procedimiento</strong>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">Procesos auditables y estandarizados, sin depender de "héroes".</span>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <LineChart className="h-6 w-6 text-brand mt-1" />
-                <div>
-                  <strong className="block text-slate-900 dark:text-slate-100">Decisiones basadas en Datos</strong>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">Analítica predictiva para anticipar problemas, no solo reportarlos.</span>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <Cog className="h-6 w-6 text-brand mt-1" />
-                <div>
-                  <strong className="block text-slate-900 dark:text-slate-100">Visión de Sistema (MBA)</strong>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">Entiendo cómo un cambio técnico impacta en la cuenta de resultados.</span>
-                </div>
-              </li>
-            </ul>
-          </div>
-          <div className="bg-white dark:bg-slate-900 p-8 rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800">
-            <h3 className="font-bold text-xl mb-4">Mi Ikigai Profesional</h3>
-            <p className="italic text-slate-600 dark:text-slate-400 mb-6">
-              "Transformar empresas en organizaciones altamente productivas mediante la integración de procesos, IA y liderazgo efectivo."
-            </p>
-            <Button as="a" href="/sobre-mi" variant="secondary" className="w-full">Conoce mi trayectoria</Button>
+      <Section className="relative">
+        <div className="rounded-3xl border border-slate-200/70 bg-white/70 p-8 shadow-xl backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/60">
+          <div className="grid md:grid-cols-2 gap-12 items-center">
+            <div>
+              <h2 className="text-3xl font-heading font-bold mb-6">Por qué un Ingeniero Aeroespacial en tu empresa</h2>
+              <p className="text-lg mb-6 text-slate-600 dark:text-slate-300">
+                La construcción y la industria moderna ya no admiten la gestión por intuición. Aplico la mentalidad de "cero defectos" y sistemas complejos al negocio.
+              </p>
+              <ul className="space-y-4">
+                <li className="flex items-start gap-3">
+                  <ShieldCheck className="h-6 w-6 text-brand mt-1" />
+                  <div>
+                    <strong className="block text-slate-900 dark:text-slate-100">Rigor y Procedimiento</strong>
+                    <span className="text-sm text-slate-600 dark:text-slate-400">Procesos auditables y estandarizados, sin depender de "héroes".</span>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <LineChart className="h-6 w-6 text-brand mt-1" />
+                  <div>
+                    <strong className="block text-slate-900 dark:text-slate-100">Decisiones basadas en Datos</strong>
+                    <span className="text-sm text-slate-600 dark:text-slate-400">Analítica predictiva para anticipar problemas, no solo reportarlos.</span>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Cog className="h-6 w-6 text-brand mt-1" />
+                  <div>
+                    <strong className="block text-slate-900 dark:text-slate-100">Visión de Sistema (MBA)</strong>
+                    <span className="text-sm text-slate-600 dark:text-slate-400">Entiendo cómo un cambio técnico impacta en la cuenta de resultados.</span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div className="bg-white/90 dark:bg-slate-950/70 p-8 rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800">
+              <h3 className="font-bold text-xl mb-4">Mi Ikigai Profesional</h3>
+              <p className="italic text-slate-600 dark:text-slate-400 mb-6">
+                "Transformar empresas en organizaciones altamente productivas mediante la integración de procesos, IA y liderazgo efectivo."
+              </p>
+              <Button as="a" href="/sobre-mi" variant="secondary" className="w-full">Conoce mi trayectoria</Button>
+            </div>
           </div>
         </div>
       </Section>
 
       {/* METODOLOGÍA */}
       <Section id="metodologia">
-        <h2 className="text-3xl font-heading mb-12 text-center font-bold">Hoja de Ruta de Transformación</h2>
+        <div className="text-center mb-12">
+          <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Método</p>
+          <h2 className="text-3xl font-heading mt-3 font-bold">Hoja de Ruta de Transformación</h2>
+        </div>
         <Timeline steps={methodology.map((m) => ({ title: m }))} />
       </Section>
 
       {/* CTA FINAL */}
       <Section id="cta-final">
-        <div className="bg-brand text-white rounded-3xl p-12 text-center shadow-2xl">
+        <div className="bg-gradient-to-r from-brand via-emerald-600 to-green-600 text-white rounded-3xl p-12 text-center shadow-2xl">
           <h2 className="text-3xl md:text-4xl font-heading font-bold mb-6">¿Tu empresa está lista para escalar?</h2>
           <p className="text-xl opacity-90 mb-8 max-w-2xl mx-auto">
             Hablemos de tus cuellos de botella y diseñemos una solución orientada al margen.

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -17,10 +17,10 @@ export default function Button({
   className,
   ...props
 }: Props) {
-  const base = 'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2';
+  const base = 'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900';
   const styles = {
-    primary: 'bg-brand text-white hover:bg-green-600',
-    secondary: 'border border-brand text-brand hover:bg-brand/10'
+    primary: 'bg-gradient-to-r from-brand to-emerald-600 text-white shadow-lg shadow-brand/30 hover:-translate-y-0.5 hover:shadow-brand/40',
+    secondary: 'border border-slate-200 bg-white/80 text-slate-700 hover:border-brand/60 hover:text-brand hover:-translate-y-0.5 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200'
   };
   return (
     <Comp className={clsx(base, styles[variant], className)} {...props}>

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,5 +1,15 @@
 import { ReactNode } from 'react';
+import clsx from 'clsx';
 
-export default function Card({ children }: { children: ReactNode }) {
-  return <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-6 shadow-sm bg-white dark:bg-slate-800">{children}</div>;
+export default function Card({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={clsx(
+        'rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm backdrop-blur transition-all duration-200 hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/80 dark:bg-slate-900/60',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
 }

--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
 
 export default function Container({ children }: { children: ReactNode }) {
-  return <div className="mx-auto max-w-5xl px-4">{children}</div>;
+  return <div className="mx-auto max-w-6xl px-4 sm:px-6">{children}</div>;
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,14 +3,14 @@ import Container from './container';
 
 export default function Footer() {
   return (
-    <footer className="mt-24 bg-slate-100 dark:bg-slate-800 text-sm">
+    <footer className="mt-24 border-t border-slate-200/70 bg-white/70 dark:border-slate-800/80 dark:bg-slate-900/60 text-sm backdrop-blur">
       <Container>
         <div className="flex flex-col md:flex-row items-center justify-between gap-4 py-6">
-          <p>© 2025 José Moya Carrasco</p>
-          <div className="flex gap-4">
-            <Link href="/aviso-legal">Aviso Legal</Link>
-            <Link href="/privacidad">Privacidad</Link>
-            <Link href="/cookies">Cookies</Link>
+          <p className="text-slate-500 dark:text-slate-400">© 2025 José Moya Carrasco</p>
+          <div className="flex gap-4 text-slate-600 dark:text-slate-300">
+            <Link href="/aviso-legal" className="hover:text-brand">Aviso Legal</Link>
+            <Link href="/privacidad" className="hover:text-brand">Privacidad</Link>
+            <Link href="/cookies" className="hover:text-brand">Cookies</Link>
           </div>
         </div>
       </Container>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -16,16 +16,22 @@ const links = [
 export default function Header() {
   const { toggle } = useTheme();
   return (
-    <header className="fixed top-0 w-full bg-white/80 dark:bg-slate-900/80 backdrop-blur z-50">
-      <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-        <Link href="/" className="font-heading text-lg font-bold">SIMPLIFY·IA</Link>
+    <header className="fixed top-0 w-full bg-white/75 dark:bg-slate-950/80 backdrop-blur border-b border-slate-200/60 dark:border-slate-800/60 z-50">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <Link href="/" className="font-heading text-lg font-bold tracking-tight">
+          SIMPLIFY·IA
+        </Link>
         <div className="hidden md:flex gap-6 items-center">
           {links.map((l) => (
-            <Link key={l.href} href={l.href} className="hover:text-brand">
+            <Link key={l.href} href={l.href} className="text-sm font-medium text-slate-600 hover:text-brand dark:text-slate-300">
               {l.label}
             </Link>
           ))}
-          <button onClick={toggle} aria-label="Cambiar tema" className="p-2 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800">
+          <button
+            onClick={toggle}
+            aria-label="Cambiar tema"
+            className="p-2 rounded-full border border-slate-200/80 bg-white/80 text-slate-600 hover:text-brand hover:border-brand/50 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300"
+          >
             <Sun className="h-4 w-4 dark:hidden" />
             <Moon className="h-4 w-4 hidden dark:block" />
           </button>

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -1,9 +1,18 @@
 import { ReactNode } from 'react';
+import clsx from 'clsx';
 import Container from './container';
 
-export default function Section({ children, id }: { children: ReactNode; id?: string }) {
+export default function Section({
+  children,
+  id,
+  className
+}: {
+  children: ReactNode;
+  id?: string;
+  className?: string;
+}) {
   return (
-    <section id={id} className="py-16">
+    <section id={id} className={clsx('py-20 sm:py-24', className)}>
       <Container>{children}</Container>
     </section>
   );

--- a/components/testimonial.tsx
+++ b/components/testimonial.tsx
@@ -7,11 +7,17 @@ interface Testimonial {
 export default function Testimonials({ items }: { items: Testimonial[] }) {
   if (!items.length) return null;
   return (
-    <div className="space-y-6">
+    <div className="grid gap-6 md:grid-cols-2">
       {items.map((t) => (
-        <blockquote key={t.quote} className="border-l-4 border-brand pl-4">
-          <p className="italic">“{t.quote}”</p>
-          <footer className="mt-2 text-sm font-medium">{t.author}{t.role && `, ${t.role}`}</footer>
+        <blockquote
+          key={t.quote}
+          className="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/60"
+        >
+          <p className="text-sm italic text-slate-600 dark:text-slate-300">“{t.quote}”</p>
+          <footer className="mt-4 text-sm font-semibold text-slate-900 dark:text-slate-100">
+            {t.author}
+            {t.role && <span className="text-slate-500 dark:text-slate-400">, {t.role}</span>}
+          </footer>
         </blockquote>
       ))}
     </div>

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -2,12 +2,16 @@ interface Step { title: string; }
 
 export default function Timeline({ steps }: { steps: Step[] }) {
   return (
-    <ol className="flex flex-col md:flex-row md:items-center md:justify-between">
+    <ol className="grid gap-6 md:grid-cols-5">
       {steps.map((s, i) => (
-        <li key={s.title} className="flex items-center md:flex-1">
-          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand text-white mr-2">{i + 1}</span>
-          <span>{s.title}</span>
-          {i < steps.length - 1 && <span className="mx-2 hidden md:block">→</span>}
+        <li
+          key={s.title}
+          className="relative flex items-start gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/60"
+        >
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand/10 text-brand font-semibold">
+            {i + 1}
+          </span>
+          <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">{s.title}</span>
         </li>
       ))}
     </ol>


### PR DESCRIPTION
### Motivation
- Improve the site's visual design and perceived quality by updating global backgrounds, spacing and typography to a more modern/premium look. 
- Make shared UI primitives (buttons, cards, timeline, testimonials, sections, container) more consistent and expressive so pages scale visually. 
- Enhance the homepage hero and section layouts with subtle decorative accents and clearer information hierarchy to boost conversion signals.

### Description
- Refreshed global styles in `app/globals.css` with softer background tones, radial accents and antialiasing, and adjusted dark-mode backgrounds.  
- Modernized UI primitives: updated `components/button.tsx` to rounded gradient buttons with motion, `components/card.tsx` to use `clsx` and backdrop blur, `components/timeline.tsx` to grid cards, and `components/testimonial.tsx` to a card grid.  
- Improved layout building blocks: increased container width in `components/container.tsx`, added optional `className` and larger vertical padding to `components/section.tsx`, and polished `components/header.tsx` and `components/footer.tsx` with refined spacing, borders and hover states.  
- Reworked the homepage (`app/page.tsx`) hero with decorative blobs, a compact feature grid, updated sector cards, revamped methodology block and CTA gradient; also removed some unused imports/icons.

### Testing
- Started the local dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and Next compiled the app successfully (server reported ready).  
- Ran a Playwright script that opened `http://localhost:3000` and produced a screenshot artifact at `artifacts/home.png`, and the script completed successfully.  
- No failing automated tests were observed during these runs; Next.js emitted a non-blocking config warning but served and compiled the site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971e52561bc832c98c9e224d8041dda)